### PR TITLE
docs: Add initial version of migration documentation

### DIFF
--- a/migration-guides/supabase-to-drizzle-migration.md
+++ b/migration-guides/supabase-to-drizzle-migration.md
@@ -1,0 +1,161 @@
+# Migrating from Supabase to Drizzle ORM in Next.js
+
+## Table of Contents
+- [Project Structure](#project-structure)
+- [Why Migrate to Drizzle ORM?](#why-migrate-to-drizzle-orm)
+- [Migration Steps](#migration-steps)
+  - [1. Initial Setup](#1-initial-setup)
+  - [2. Database Configuration](#2-database-configuration)
+  - [3. Schema Definition](#3-schema-definition)
+  - [4. Database Migrations](#4-database-migrations)
+  - [5. Query Migration](#5-query-migration)
+- [References and Documentation 📚](#references-and-documentation-📚)
+
+## Project Structure
+```bash
+your-nextjs-project/
+├── drizzle/               # Generated migrations directory
+├── src/
+│   ├── db/
+│   │   ├── index.ts      # Database connection
+│   │   └── schema.ts     # Schema definitions
+│   └── app/              # Next.js application code
+├── drizzle.config.ts     # Drizzle configuration
+├── .env                  # Environment variables
+└── package.json
+```
+
+## Why Migrate to Drizzle ORM?
+Drizzle ORM offers several advantages:
+- 🚀 **Lightweight & Efficient**: Minimal overhead and bundle size
+- 🛠️ **Type-safe**: Full TypeScript support with automated type inference
+- 📈 **High Performance**: Optimized query building and execution
+- 💻 **Developer Friendly**: Intuitive API and excellent DX
+
+## Migration Steps
+
+### 1. Initial Setup
+
+Install required packages:
+```bash
+npm i drizzle-orm
+npm i -D drizzle-kit
+npm i dotenv
+npm i postgres
+```
+
+Create a `.env` file in your project root:
+```env
+DATABASE_URL="postgres://user:password@host:port/database"
+```
+
+### 2. Database Configuration
+
+Create `drizzle.config.ts` in your project root:
+```typescript
+import { config } from 'dotenv';
+import { defineConfig } from 'drizzle-kit';
+config({ path: '.env' });
+
+export default defineConfig({
+  out: './drizzle',
+  schema: './src/db/schema.ts',
+  dialect: 'postgresql',
+  dbCredentials: {
+    connectionString: process.env.DATABASE_URL!,
+  },
+});
+```
+
+Create `src/db/index.ts` for database connection:
+```typescript
+import { config } from 'dotenv';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+config({ path: '.env' }); // or .env.local
+const client = postgres(process.env.DATABASE_URL!);
+export const db = drizzle({ client });
+```
+
+### 3. Schema Definition
+
+Create `src/db/schema.ts` to define your database schema:
+```typescript
+import { integer, pgTable, varchar, text } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: integer("id").primaryKey().notNull(),
+  name: varchar("name", { length: 255 }).notNull(),
+  email: text("email").notNull().unique(),
+});
+```
+
+### 4. Database Migrations
+
+You have two options for managing your database schema:
+
+#### Option A: Direct Push (Development)
+For quick development iterations, use push:
+```bash
+npx drizzle-kit push
+```
+
+#### Option B: Migration Files (Recommended for Production)
+Generate and apply migrations:
+```bash
+# Generate migration files
+npx drizzle-kit generate
+
+# Apply migrations
+npx drizzle-kit migrate
+```
+
+### 5. Query Migration
+
+Update your existing Supabase queries to use Drizzle:
+
+```typescript
+// Before (Supabase)
+const { data: users, error } = await supabase
+  .from('users')
+  .select('*');
+
+// After (Drizzle)
+import { db } from '@/db';
+import { users } from '@/db/schema';
+
+const allUsers = await db.select().from(users);
+```
+
+More complex query examples:
+
+```typescript
+// Insert
+const newUser = await db.insert(users).values({
+  name: 'John Doe',
+  email: 'john@example.com',
+}).returning();
+
+// Update
+const updated = await db
+  .update(users)
+  .set({ name: 'Jane Doe' })
+  .where(eq(users.id, 1))
+  .returning();
+
+// Delete
+const deleted = await db
+  .delete(users)
+  .where(eq(users.id, 1))
+  .returning();
+```
+
+### References and Documentation 📚
+
+To explore more about Drizzle ORM, refer to the official documentation:
+
+- [PostgreSQL Column Types](https://orm.drizzle.team/docs/column-types/pg): Comprehensive guide to all supported PostgreSQL data types in Drizzle ORM. Use this to define your schema accurately.
+- [Drizzle Query Builder (RQB)](https://orm.drizzle.team/docs/rqb): Detailed documentation for building queries with Drizzle ORM, including advanced querying techniques.
+
+These resources will help you understand the specifics of column types and query construction, making your migration process smoother.

--- a/migration-guides/supabase-to-drizzle-schema-pull.md
+++ b/migration-guides/supabase-to-drizzle-schema-pull.md
@@ -1,0 +1,112 @@
+# Pulling Supabase Schema into Drizzle ORM
+
+## Overview
+This guide shows how to pull your existing Supabase database schema into Drizzle ORM, making it easy to migrate your database structure.
+
+## Prerequisites
+- Existing Supabase project
+- Next.js project with Drizzle ORM installed
+- Supabase connection credentials
+
+## Steps
+
+### 1. Get Supabase Connection String
+Get your database connection string from Supabase:
+1. Go to your Supabase project dashboard
+2. Navigate to Project Settings → Database
+3. Find the Connection String (URI) under Connection Info
+4. Copy the connection string that looks like:
+```
+postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+```
+
+### 2. Configure Drizzle
+Create `drizzle.config.ts` in your project root:
+
+```typescript
+import 'dotenv/config';
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'postgresql',
+  out: './drizzle',
+  schema: './src/db/schema.ts',
+  dbCredentials: {
+    connectionString: process.env.DATABASE_URL!,
+  },
+  // Optionally filter specific tables/schemas
+  tablesFilter: ['*'], // or ['users', 'posts'] for specific tables
+  schemaFilter: ['public'], // Supabase stores user tables in public schema
+  // Exclude Supabase's internal schemas
+  schemas: ['public'],
+  // Ignore Supabase's internal tables
+  tablesFilter: ['!realtime*', '!auth*', '!storage*', '*'],
+});
+```
+
+### 3. Pull the Schema
+Run the pull command to generate your schema file:
+
+```bash
+npx drizzle-kit pull
+```
+
+This will create a `schema.ts` file with your database structure.
+
+### 4. Review and Customize
+Check the generated schema in `src/db/schema.ts`. You might want to:
+- Add TypeScript types
+- Modify column configurations
+- Add indexes or relationships
+- Remove any unwanted tables
+
+Example of a generated schema:
+```typescript
+import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+  name: text('name'),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+// Other tables will be added here
+```
+
+## Tips
+- Use `.env` for database credentials
+- Exclude Supabase's system tables using filters
+- Review the generated schema for accuracy
+- Add custom configurations after pulling
+
+## Common Issues
+
+1. **Authentication Error**
+```bash
+# Make sure your connection string is correct and includes:
+- Correct project reference
+- Valid database password
+- Proper host and port
+```
+
+2. **Missing Tables**
+```typescript
+// Adjust tablesFilter in drizzle.config.ts
+tablesFilter: ['*'], // Pull all tables
+// or
+tablesFilter: ['users', 'posts'], // Pull specific tables
+```
+
+3. **System Tables Included**
+```typescript
+// Add filters to exclude Supabase system tables
+tablesFilter: ['!realtime*', '!auth*', '!storage*', '*'],
+```
+
+## Next Steps
+After pulling your schema:
+1. Set up your database connection
+2. Migrate existing queries to Drizzle
+3. Test your database operations
+4. Consider setting up migrations for future changes


### PR DESCRIPTION
Add initial migration docs

This PR adds the first version of the migration documentation, explaining the steps to migrate from Supabase to Drizzle ORM. Please review.
